### PR TITLE
Botbuilder update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [*Unreleased*]
+## [*1.6.0*] - <*2020-05-17*>
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botbuilder-teams-messagingextensions",
-  "version": "1.6.0-preview",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -56,8 +56,8 @@
     },
     "assert": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
-      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "resolved": "https://artifactory.factset.com/artifactory/api/npm/npm/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -71,19 +71,19 @@
       "dev": true
     },
     "botbuilder-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.7.2.tgz",
-      "integrity": "sha512-4adVtnCB6+d+R6SJQlpd9HLzvLcBmuu9i/wqcvLaTiWen2Jv6+n8mHNsSg2lR2grIIYbV0ZKqfb0FLnlvFWH4A==",
+      "version": "4.9.2",
+      "resolved": "https://artifactory.factset.com/artifactory/api/npm/npm/botbuilder-core/-/botbuilder-core-4.9.2.tgz",
+      "integrity": "sha1-njBevc19gjHXH/OOZlPjb7uRxes=",
       "dev": true,
       "requires": {
         "assert": "^1.4.1",
-        "botframework-schema": "4.7.2"
+        "botframework-schema": "4.9.2"
       }
     },
     "botframework-schema": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.7.2.tgz",
-      "integrity": "sha512-rSTywVl5dYzL4FNoK86s9kFPNkRx5iYJi7MAWEaSrhUiDV3KEHX/5VEHLa00d4nzQxC/jI9BqfbqdffpO97KIA==",
+      "version": "4.9.2",
+      "resolved": "https://artifactory.factset.com/artifactory/api/npm/npm/botframework-schema/-/botframework-schema-4.9.2.tgz",
+      "integrity": "sha1-Lb7G+5WzRDf6QetzVN4qWjU4Oyo=",
       "dev": true
     },
     "brace-expansion": {
@@ -255,7 +255,7 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://artifactory.factset.com/artifactory/api/npm/npm/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
@@ -354,7 +354,7 @@
     },
     "util": {
       "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "resolved": "https://artifactory.factset.com/artifactory/api/npm/npm/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -311,9 +311,9 @@
       }
     },
     "tslib": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-      "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "tslint": {
@@ -347,9 +347,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+      "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
       "dev": true
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botbuilder-teams-messagingextensions",
-  "version": "1.6.0-preview",
+  "version": "1.6.0",
   "description": "Microsoft Bot Builder Framework v4 middleware for Microsoft Teams Messaging Extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/debug": "^4.1.4",
     "tslint": "^5.14.0",
     "typescript": "^3.3.4000",
-    "botbuilder-core": "~4.7.1"
+    "botbuilder-core": "~4.9.2"
   },
   "dependencies": {
     "debug": "4.1.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,7 @@ export class MessagingExtensionMiddleware implements Middleware {
                         this.processor.onFetchTask) {
                         try {
                             const result = await this.processor.onFetchTask(context, context.activity.value);
-                            const body = result.type === "continue" || result.type === "message" ?
+                            const body = result.type === "message" ?
                                 { task: result } :
                                 { composeExtension: result };
                             context.sendActivity({


### PR DESCRIPTION
This updates the dependency on botbuilder-core to 4.9.2 in order to work with the botbuilder, botbuilder-dialogs, and botframework-connector packages of the same version. The botbuilder/botframework packages altered their typings and are incompatible with botbuilder-core 4.7.1 which this project previously relied on.