### PR TITLE
Added support for botMessagePreview functionality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,7 @@ export class MessagingExtensionMiddleware implements Middleware {
                                     body = {
                                         task: result,
                                     };
+                                    break;
                                 default:
                                     result = await this.processor.onSubmitAction(context, context.activity.value);
                                     body = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,7 +250,7 @@ export class MessagingExtensionMiddleware implements Middleware {
                     if ((this.commandId === context.activity.value.commandId || this.commandId === undefined) &&
                         (this.processor.onSubmitAction || this.processor.onBotMessagePreviewEdit || this.processor.onBotMessagePreviewSend)) {
                         try {
-                            let result: MessagingExtensionResult | TaskModuleContinueResponse;
+                            let result;
                             let body;
                             switch (context.activity.value.botMessagePreviewAction) {
                                 case "send":

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,9 +65,9 @@ export interface IMessagingExtensionMiddlewareProcessor {
      * Processes incoming link actions (composeExtension/submitAction) where the `botMessagePreviewAction` is set to `edit`
      * @param context the turn context
      * @param value the value of the query
-     * @returns {Promise<MessagingExtensionResult>}
+     * @returns {Promise<TaskModuleContinueResponse>}
      */
-    onBotMessagePreviewEdit?(context: TurnContext, value: MessagingExtensionAction): Promise<MessagingExtensionResult | TaskModuleContinueResponse>;
+    onBotMessagePreviewEdit?(context: TurnContext, value: MessagingExtensionAction): Promise<TaskModuleContinueResponse>;
     /**
      * Processes incoming fetch task actions (`composeExtension/fetchTask`)
      * @param context the turn context
@@ -250,7 +250,7 @@ export class MessagingExtensionMiddleware implements Middleware {
                     if ((this.commandId === context.activity.value.commandId || this.commandId === undefined) &&
                         (this.processor.onSubmitAction || this.processor.onBotMessagePreviewEdit || this.processor.onBotMessagePreviewSend)) {
                         try {
-                            let result;
+                            let result: MessagingExtensionResult | TaskModuleContinueResponse;
                             let body;
                             switch (context.activity.value.botMessagePreviewAction) {
                                 case "send":

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,20 @@ export interface IMessagingExtensionMiddlewareProcessor {
      */
     onSubmitAction?(context: TurnContext, value: MessagingExtensionAction): Promise<MessagingExtensionResult>;
     /**
+     * Processes incoming link actions (composeExtension/submitAction) where the `botMessagePreviewAction` is set to `send`
+     * @param context the turn context
+     * @param value the value of the query
+     * @returns {Promise<MessagingExtensionResult>}
+     */
+    onBotMessagePreviewSend?(context: TurnContext, value: MessagingExtensionAction): Promise<MessagingExtensionResult>;
+    /**
+     * Processes incoming link actions (composeExtension/submitAction) where the `botMessagePreviewAction` is set to `edit`
+     * @param context the turn context
+     * @param value the value of the query
+     * @returns {Promise<MessagingExtensionResult>}
+     */
+    onBotMessagePreviewEdit?(context: TurnContext, value: MessagingExtensionAction): Promise<MessagingExtensionResult | TaskModuleContinueResponse>;
+    /**
      * Processes incoming fetch task actions (`composeExtension/fetchTask`)
      * @param context the turn context
      * @param value commandContext
@@ -234,15 +248,32 @@ export class MessagingExtensionMiddleware implements Middleware {
                     break;
                 case "composeExtension/submitAction":
                     if ((this.commandId === context.activity.value.commandId || this.commandId === undefined) &&
-                        this.processor.onSubmitAction) {
+                        (this.processor.onSubmitAction || this.processor.onBotMessagePreviewEdit || this.processor.onBotMessagePreviewSend)) {
                         try {
-                            const result = await this.processor.onSubmitAction(context, context.activity.value);
+                            let result;
+                            let body;
+                            switch (context.activity.value.botMessagePreviewAction) {
+                                case "send":
+                                    result = await this.processor.onBotMessagePreviewSend(context, context.activity.value);
+                                    body = result;
+                                    break;
+                                case "edit":
+                                    result = await this.processor.onBotMessagePreviewEdit(context, context.activity.value);
+                                    body = {
+                                        task: result,
+                                    };
+                                default:
+                                    result = await this.processor.onSubmitAction(context, context.activity.value);
+                                    body = {
+                                        composeExtension: result,
+                                    };
+                                    break;
+                            }
+
                             context.sendActivity({
                                 type: INVOKERESPONSE,
                                 value: {
-                                    body: {
-                                        composeExtension: result,
-                                    },
+                                    body,
                                     status: 200,
                                 },
                             });


### PR DESCRIPTION
Added support for the `botMessagePreview` feature documented [here](https://docs.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/action-commands/respond-to-task-module-submit?tabs=dotnet#bot-response-with-adaptive-card). This PR resolves [this](https://github.com/wictorwilen/botbuilder-teams-messagingextensions/issues/8) issue.